### PR TITLE
Fix go-git-ignore dependency from the original project

### DIFF
--- a/drive/sync.go
+++ b/drive/sync.go
@@ -2,7 +2,7 @@ package drive
 
 import (
 	"fmt"
-	"github.com/sabhiram/go-git-ignore"
+	"github.com/sabhiram/go-gitignore"
 	"github.com/soniakeys/graph"
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/googleapi"


### PR DESCRIPTION
 This dependency prevent the command "go install" to succeed with error :
 ```
 go: github.com/petrpulc/gdrive imports
	github.com/petrpulc/gdrive/drive imports
	github.com/sabhiram/go-git-ignore: github.com/sabhiram/go-git-ignore@v0.0.0-20210923224102-525f6e181f06: parsing go.mod:
	module declares its path as: github.com/sabhiram/go-gitignore
	        but was required as: github.com/sabhiram/go-git-ignore
 ```